### PR TITLE
feat: robot-managerを追加（craneリポジトリから移行）

### DIFF
--- a/.github/workflows/robot-manager-docker.yml
+++ b/.github/workflows/robot-manager-docker.yml
@@ -1,0 +1,40 @@
+name: robot-manager docker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'robot-manager/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build robot-manager image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./robot-manager
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/robot-manager:latest
+            ghcr.io/${{ github.repository_owner }}/robot-manager:${{ github.sha }}
+          cache-from: type=gha,scope=robot-manager
+          cache-to: type=gha,mode=max,scope=robot-manager

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  robot-manager:
+    build:
+      context: ./robot-manager
+    container_name: orion-robot-manager
+    ports:
+      - "${HTTP_PORT:-8090}:${HTTP_PORT:-8090}"
+    environment:
+      - HTTP_PORT=${HTTP_PORT:-8090}
+      - NUM_ROBOTS=${NUM_ROBOTS:-13}
+      - ROBOT_IP_BASE=${ROBOT_IP_BASE:-192.168.20.}
+      - ROBOT_IP_OFFSET=${ROBOT_IP_OFFSET:-100}
+      - ROBOT_PORT=${ROBOT_PORT:-8000}
+      - HTTP_TIMEOUT_SEC=${HTTP_TIMEOUT_SEC:-0.8}
+      - BACK_URL=${BACK_URL:-}
+    restart: unless-stopped

--- a/robot-manager/Dockerfile
+++ b/robot-manager/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY server.py /app/server.py
+COPY web /app/web
+
+EXPOSE 8090
+
+ENV HTTP_PORT=8090
+
+CMD ["python3", "/app/server.py"]

--- a/robot-manager/server.py
+++ b/robot-manager/server.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import signal
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+NUM_ROBOTS = int(os.environ.get("NUM_ROBOTS", "13"))
+ROBOT_IP_BASE = os.environ.get("ROBOT_IP_BASE", "192.168.20.")
+ROBOT_IP_OFFSET = int(os.environ.get("ROBOT_IP_OFFSET", "100"))
+ROBOT_PORT = int(os.environ.get("ROBOT_PORT", "8000"))
+HTTP_PORT = int(os.environ.get("HTTP_PORT", "8090"))
+HTTP_TIMEOUT_SEC = float(os.environ.get("HTTP_TIMEOUT_SEC", "0.8"))
+BACK_URL = os.environ.get("BACK_URL", "")
+
+
+def robot_ip(robot_id: int) -> str:
+    return f"{ROBOT_IP_BASE}{ROBOT_IP_OFFSET + robot_id}"
+
+
+def parse_status(success: bool, body_text: str, default_ok: str = "Running") -> str:
+    if not success:
+        return "Offline"
+    if not body_text:
+        return default_ok
+    try:
+        body_json = json.loads(body_text)
+    except json.JSONDecodeError:
+        return default_ok
+    status = body_json.get("status")
+    if isinstance(status, str) and status:
+        return status
+    return default_ok
+
+
+def send_pi_request(robot_id: int, method: str, path: str) -> tuple[bool, str]:
+    target = f"http://{robot_ip(robot_id)}:{ROBOT_PORT}{path}"
+    req = Request(target, method=method)
+    try:
+        with urlopen(req, timeout=HTTP_TIMEOUT_SEC) as resp:
+            ok = 200 <= resp.status < 300
+            body = resp.read().decode("utf-8", errors="replace")
+            return ok, body
+    except URLError:
+        return False, ""
+    except TimeoutError:
+        return False, ""
+    except Exception:
+        return False, ""
+
+
+def get_robot_status(robot_id: int) -> dict:
+    ok, body = send_pi_request(robot_id, "GET", "/status")
+    result: dict = {
+        "robot_id": robot_id,
+        "ip": robot_ip(robot_id),
+        "success": ok,
+        "status": parse_status(ok, body),
+    }
+    # Pi が返す追加フィールド（voltage, temperatures, error_id, error_info 等）をパススルー
+    if ok and body:
+        try:
+            body_json = json.loads(body)
+            for key, value in body_json.items():
+                if key not in result:
+                    result[key] = value
+        except json.JSONDecodeError:
+            pass
+    return result
+
+
+def control_robot(robot_id: int, command: str) -> dict:
+    command_map = {
+        "start": ("POST", "/start"),
+        "stop": ("POST", "/stop"),
+        "status": ("GET", "/status"),
+    }
+    if command not in command_map:
+        return {
+            "robot_id": robot_id,
+            "command": command,
+            "success": False,
+            "status": "Unknown command",
+        }
+    method, path = command_map[command]
+    ok, body = send_pi_request(robot_id, method, path)
+    result: dict = {
+        "robot_id": robot_id,
+        "command": command,
+        "success": ok,
+        "status": parse_status(ok, body),
+    }
+    # Pi が返す追加フィールドをパススルー
+    if ok and body:
+        try:
+            body_json = json.loads(body)
+            for key, value in body_json.items():
+                if key not in result:
+                    result[key] = value
+        except json.JSONDecodeError:
+            pass
+    return result
+
+
+WEB_DIR = Path(__file__).resolve().parent / "web"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _json(self, payload: dict | list, status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _text(self, text: str, status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = text.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_static(self, rel_path: str) -> None:
+        rel = rel_path.lstrip("/")
+        if rel == "":
+            rel = "index.html"
+        target = (WEB_DIR / rel).resolve()
+        if not str(target).startswith(str(WEB_DIR.resolve())) or not target.exists():
+            self._text("Not Found", HTTPStatus.NOT_FOUND)
+            return
+
+        content_type = "application/octet-stream"
+        if target.suffix == ".html":
+            content_type = "text/html; charset=utf-8"
+        elif target.suffix == ".js":
+            content_type = "application/javascript; charset=utf-8"
+        elif target.suffix == ".css":
+            content_type = "text/css; charset=utf-8"
+        elif target.suffix == ".svg":
+            content_type = "image/svg+xml"
+        elif target.suffix == ".woff2":
+            content_type = "font/woff2"
+        elif target.suffix == ".woff":
+            content_type = "font/woff"
+        elif target.suffix == ".ttf":
+            content_type = "font/ttf"
+        elif target.suffix == ".ico":
+            content_type = "image/x-icon"
+
+        data = target.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _parse_robot_id(self, text: str) -> int | None:
+        try:
+            robot_id = int(text)
+        except ValueError:
+            return None
+        if 0 <= robot_id < NUM_ROBOTS:
+            return robot_id
+        return None
+
+    def do_GET(self) -> None:
+        if self.path == "/healthz":
+            self._json({"ok": True, "service": "robot-manager"})
+            return
+
+        if self.path == "/api/config":
+            self._json({"num_robots": NUM_ROBOTS, "back_url": BACK_URL})
+            return
+
+        if self.path == "/api/robots":
+            with ThreadPoolExecutor(max_workers=min(8, NUM_ROBOTS)) as ex:
+                robots = list(ex.map(get_robot_status, range(NUM_ROBOTS)))
+            self._json({"type": "pi_status", "robots": robots})
+            return
+
+        if self.path.startswith("/api/robots/") and self.path.endswith("/status"):
+            robot_id_str = self.path[len("/api/robots/") : -len("/status")]
+            robot_id = self._parse_robot_id(robot_id_str.strip("/"))
+            if robot_id is None:
+                self._json({"error": "invalid robot_id"}, HTTPStatus.BAD_REQUEST)
+                return
+            self._json(control_robot(robot_id, "status"))
+            return
+
+        self._serve_static(self.path)
+
+    def do_POST(self) -> None:
+        if self.path.startswith("/api/robots/") and self.path.endswith("/start"):
+            robot_id_str = self.path[len("/api/robots/") : -len("/start")]
+            robot_id = self._parse_robot_id(robot_id_str.strip("/"))
+            if robot_id is None:
+                self._json({"error": "invalid robot_id"}, HTTPStatus.BAD_REQUEST)
+                return
+            self._json(control_robot(robot_id, "start"))
+            return
+
+        if self.path.startswith("/api/robots/") and self.path.endswith("/stop"):
+            robot_id_str = self.path[len("/api/robots/") : -len("/stop")]
+            robot_id = self._parse_robot_id(robot_id_str.strip("/"))
+            if robot_id is None:
+                self._json({"error": "invalid robot_id"}, HTTPStatus.BAD_REQUEST)
+                return
+            self._json(control_robot(robot_id, "stop"))
+            return
+
+        self._json({"error": "Not Found"}, HTTPStatus.NOT_FOUND)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", HTTP_PORT), Handler)
+    print(f"robot-manager listening on http://0.0.0.0:{HTTP_PORT}")
+
+    def handle_signal(signum, frame):
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/robot-manager/web/app.js
+++ b/robot-manager/web/app.js
@@ -1,0 +1,406 @@
+'use strict';
+
+// ---- 定数 ------------------------------------------------------------------
+
+let NUM_ROBOTS = 13;
+
+// 温度センサーのコンポーネント名（インデックス順）
+const TEMP_NAMES = ['RF', 'RB', 'LB', 'LF', 'FET', 'コイル1', 'コイル2'];
+const TEMP_WARN = 45;
+const TEMP_CRIT = 60;
+
+// 電圧しきい値
+const VOLTAGE_WARN = 23.0;
+const VOLTAGE_CRIT = 22.0;
+
+// ---- ステータス設定 ---------------------------------------------------------
+
+const STATUS_CONFIG = {
+  running: { badge: 'm3-badge--success', label: '稼働中' },
+  stopped: { badge: 'm3-badge--warning', label: '停止中' },
+  error:   { badge: 'm3-badge--error',   label: 'エラー' },
+  offline: { badge: 'm3-badge--secondary', label: 'オフライン' },
+};
+
+// ---- 状態 ------------------------------------------------------------------
+
+let robots = [];
+let pendingControlIds = new Set();
+
+// ---- DOM参照 ---------------------------------------------------------------
+
+const tableBody = document.getElementById('table-body');
+const connDot = document.getElementById('conn-dot');
+const connText = document.getElementById('conn-text');
+const runningCount = document.getElementById('running-count');
+const stoppedCount = document.getElementById('stopped-count');
+const offlineCount = document.getElementById('offline-count');
+const lastUpdatedEl = document.getElementById('last-updated');
+const refreshBtn = document.getElementById('refresh-btn');
+const startAllBtn = document.getElementById('start-all-btn');
+const stopAllBtn = document.getElementById('stop-all-btn');
+
+// ---- 接続状態 --------------------------------------------------------------
+
+function setConnected(ok) {
+  connDot.className = ok ? 'm3-connection-dot connected' : 'm3-connection-dot';
+  connText.textContent = ok ? '接続済み' : '切断';
+}
+
+// ---- エラーデコード ---------------------------------------------------------
+
+function getErrorString(error_id, error_info) {
+  if (!error_info) return null;
+
+  if (error_id === 100) {
+    // POWERボードエラー
+    const bits = [
+      [0x0001, '低電圧'],
+      [0x0002, '過電圧'],
+      [0x0004, '過電流'],
+      [0x0008, '短絡'],
+      [0x0010, '充電タイムアウト'],
+      [0x0020, '充電電力異常'],
+      [0x0040, '放電異常'],
+      [0x0080, 'パラメータ異常'],
+      [0x0100, 'コマンド異常'],
+      [0x0200, 'キャパシタ未接続'],
+      [0x0400, '放電失敗'],
+      [0x0800, 'GD電源異常'],
+      [0x1000, 'コイル過熱'],
+      [0x2000, 'FET過熱'],
+    ];
+    const errors = bits.filter(([bit]) => error_info & bit).map(([, name]) => name);
+    return 'POWER: ' + (errors.length ? errors.join(', ') : '不明');
+  }
+
+  if (error_id <= 3) {
+    // BLDCモーターエラー（モーター位置付き）
+    const motorNames = ['RF', 'RB', 'LB', 'LF'];
+    const motorName = motorNames[error_id] ?? `M${error_id}`;
+    const bits = [
+      [0x0001, '低電圧'],
+      [0x0002, '過電流'],
+      [0x0004, 'モーター過熱'],
+      [0x0008, '過負荷'],
+      [0x0010, 'エンコーダエラー'],
+      [0x0020, '過電圧'],
+      [0x0040, 'FET過熱'],
+    ];
+    const errors = bits.filter(([bit]) => error_info & bit).map(([, name]) => name);
+    return `BLDC[${motorName}]: ` + (errors.length ? errors.join(', ') : '不明');
+  }
+
+  return `ERR(id=${error_id}, info=0x${error_info.toString(16)})`;
+}
+
+// ---- ハードウェア詳細レンダリング -------------------------------------------
+
+function renderHwDetail(robot) {
+  const parts = [];
+
+  // 電圧（配列の最初の値を使用）
+  if (Array.isArray(robot.voltage) && robot.voltage.length > 0) {
+    const v = robot.voltage[0];
+    const cls = v < VOLTAGE_CRIT ? 'm3-text-error' : v < VOLTAGE_WARN ? 'm3-text-warning' : 'm3-text-success';
+    parts.push(`<span class="${cls}">⚡${v.toFixed(1)}V</span>`);
+  }
+
+  // 温度（最大温度とそのコンポーネント名）
+  if (Array.isArray(robot.temperatures) && robot.temperatures.length > 0) {
+    const temps = robot.temperatures;
+    const maxTemp = Math.max(...temps);
+    const maxIdx = temps.indexOf(maxTemp);
+    const label = TEMP_NAMES[maxIdx] ?? `T${maxIdx}`;
+    const cls = maxTemp >= TEMP_CRIT ? 'm3-text-error' : maxTemp >= TEMP_WARN ? 'm3-text-warning' : '';
+    parts.push(`<span class="${cls}">🌡${maxTemp}°C (${label})</span>`);
+  }
+
+  // エラー（デコード済み）
+  if (robot.error_id !== undefined && robot.error_info) {
+    const errStr = getErrorString(robot.error_id, robot.error_info);
+    if (errStr) {
+      parts.push(`<span class="m3-text-error">${errStr}</span>`);
+    }
+  }
+
+  if (parts.length === 0) {
+    return '<span class="m3-text-on-surface-variant">--</span>';
+  }
+
+  return parts.map((p, i) =>
+    i === 0 ? p : `<span class="hw-divider">|</span>${p}`
+  ).join('');
+}
+
+// ---- ステータス分類 ---------------------------------------------------------
+
+function classifyStatus(status) {
+  const s = (status || '').toLowerCase();
+  if (s.includes('run')) return 'running';
+  if (s.includes('stop')) return 'stopped';
+  if (s.includes('error')) return 'error';
+  return 'offline';
+}
+
+// ---- テーブル描画 -----------------------------------------------------------
+
+function rowHtml(robot) {
+  const cls = classifyStatus(robot.status);
+  const cfg = STATUS_CONFIG[cls] ?? STATUS_CONFIG.offline;
+  const isBusy = pendingControlIds.has(robot.robot_id);
+  const disabledAttr = isBusy ? 'disabled' : '';
+
+  return `
+    <tr class="robot-row ${cls === 'offline' ? 'offline' : ''}" id="robot-row-${robot.robot_id}">
+      <td>
+        <span class="material-symbols-outlined icon-sm m3-text-on-surface-variant"
+              style="vertical-align:middle;margin-right:4px">smart_toy</span>
+        <strong>#${robot.robot_id}</strong>
+      </td>
+      <td>
+        <div class="m3-flex m3-items-center m3-gap-sm">
+          <span class="m3-badge ${cfg.badge}" style="min-width:72px">${cfg.label}</span>
+          <div class="m3-flex m3-gap-xs">
+            <button class="m3-icon-btn m3-icon-btn--sm"
+                    onclick="controlRobot(${robot.robot_id}, 'start')"
+                    title="起動" ${disabledAttr}
+                    style="color:var(--md-sys-color-success)">
+              <span class="material-symbols-outlined icon-sm">play_arrow</span>
+            </button>
+            <button class="m3-icon-btn m3-icon-btn--sm"
+                    onclick="controlRobot(${robot.robot_id}, 'stop')"
+                    title="停止" ${disabledAttr}
+                    style="color:var(--md-sys-color-error)">
+              <span class="material-symbols-outlined icon-sm">stop</span>
+            </button>
+          </div>
+        </div>
+      </td>
+      <td class="col-ip">
+        <span class="m3-text-on-surface-variant m3-body-small m3-tabular-nums">
+          ${robot.ip || '--'}
+        </span>
+      </td>
+      <td>
+        <div class="hw-detail">${renderHwDetail(robot)}</div>
+      </td>
+    </tr>`;
+}
+
+function renderTable() {
+  if (robots.length === 0) {
+    tableBody.innerHTML = `
+      <tr><td colspan="4" style="text-align:center;padding:24px">
+        <span class="m3-text-on-surface-variant">データなし</span>
+      </td></tr>`;
+    return;
+  }
+  tableBody.innerHTML = robots.map(rowHtml).join('');
+  renderSummary();
+}
+
+function renderSummary() {
+  let run = 0, stop = 0, off = 0;
+  for (const r of robots) {
+    const cls = classifyStatus(r.status);
+    if (cls === 'running') run++;
+    else if (cls === 'stopped') stop++;
+    else off++;
+  }
+  runningCount.textContent = String(run);
+  stoppedCount.textContent = String(stop);
+  offlineCount.textContent = String(off);
+}
+
+function updateLastUpdated() {
+  const now = new Date();
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mm = String(now.getMinutes()).padStart(2, '0');
+  const ss = String(now.getSeconds()).padStart(2, '0');
+  lastUpdatedEl.textContent = `最終更新: ${hh}:${mm}:${ss}`;
+}
+
+// ---- オフラインフォールバック ------------------------------------------------
+
+function offlineRobots() {
+  return Array.from({ length: NUM_ROBOTS }, (_, id) => ({
+    robot_id: id,
+    ip: `192.168.20.${100 + id}`,
+    success: false,
+    status: 'Offline',
+  }));
+}
+
+// ---- API通信 ---------------------------------------------------------------
+
+async function fetchRobots() {
+  try {
+    const res = await fetch('/api/robots', { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    robots = data.robots || [];
+    renderTable();
+    setConnected(true);
+    updateLastUpdated();
+  } catch {
+    setConnected(false);
+    robots = offlineRobots();
+    renderTable();
+  }
+}
+
+async function controlRobot(robotId, command) {
+  if (pendingControlIds.has(robotId)) return;
+  pendingControlIds.add(robotId);
+  renderTable();
+  try {
+    const res = await fetch(`/api/robots/${robotId}/${command}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const label = command === 'start' ? '起動' : '停止';
+    const ok = data.success !== false;
+    showToast(`ロボット #${robotId}: ${label}${ok ? '成功' : '失敗'}`, ok ? 'success' : 'error');
+  } catch {
+    showToast(`ロボット #${robotId}: 通信エラー`, 'error');
+    setConnected(false);
+  } finally {
+    pendingControlIds.delete(robotId);
+    await fetchRobots();
+  }
+}
+
+window.controlRobot = controlRobot;
+
+async function startAll() {
+  try {
+    startAllBtn.disabled = true;
+    await Promise.all(
+      Array.from({ length: NUM_ROBOTS }, (_, id) =>
+        fetch(`/api/robots/${id}/start`, { method: 'POST' })
+      )
+    );
+    await fetchRobots();
+    showToast('全台起動コマンドを送信しました', 'success');
+  } catch {
+    showToast('一部のロボットへの通信に失敗しました', 'error');
+    setConnected(false);
+    robots = offlineRobots();
+    renderTable();
+  } finally {
+    startAllBtn.disabled = false;
+  }
+}
+
+async function stopAll() {
+  const confirmed = await showConfirm(
+    '全台停止',
+    `全${NUM_ROBOTS}台のロボットを停止します。よろしいですか？`
+  );
+  if (!confirmed) return;
+  try {
+    stopAllBtn.disabled = true;
+    await Promise.all(
+      Array.from({ length: NUM_ROBOTS }, (_, id) =>
+        fetch(`/api/robots/${id}/stop`, { method: 'POST' })
+      )
+    );
+    await fetchRobots();
+    showToast('全台停止コマンドを送信しました', 'info');
+  } catch {
+    showToast('一部のロボットへの通信に失敗しました', 'error');
+    setConnected(false);
+    robots = offlineRobots();
+    renderTable();
+  } finally {
+    stopAllBtn.disabled = false;
+  }
+}
+
+// ---- トースト通知 -----------------------------------------------------------
+
+function showToast(message, type = 'info') {
+  const iconMap = { success: 'check_circle', error: 'error', info: 'info' };
+  const container = document.getElementById('toast-container');
+  const toast = document.createElement('div');
+  toast.className = `m3-toast m3-toast--${type}`;
+  toast.innerHTML = `
+    <span class="material-symbols-outlined icon-sm">${iconMap[type] ?? 'info'}</span>
+    <span>${message}</span>`;
+  container.appendChild(toast);
+  setTimeout(() => {
+    toast.classList.add('exit');
+    setTimeout(() => toast.remove(), 300);
+  }, 3000);
+}
+
+// ---- 確認ダイアログ ---------------------------------------------------------
+
+function showConfirm(title, body) {
+  return new Promise((resolve) => {
+    const scrim = document.getElementById('confirm-scrim');
+    const dialog = document.getElementById('confirm-dialog');
+    document.getElementById('confirm-title').textContent = title;
+    document.getElementById('confirm-body').textContent = body;
+
+    scrim.style.display = 'block';
+    dialog.style.display = 'block';
+    // アニメーション起動
+    requestAnimationFrame(() => {
+      scrim.classList.add('open');
+      dialog.classList.add('open');
+    });
+
+    function close(result) {
+      scrim.classList.remove('open');
+      dialog.classList.remove('open');
+      setTimeout(() => {
+        scrim.style.display = 'none';
+        dialog.style.display = 'none';
+      }, 200);
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      resolve(result);
+    }
+
+    const okBtn = document.getElementById('confirm-ok');
+    const cancelBtn = document.getElementById('confirm-cancel');
+    function onOk() { close(true); }
+    function onCancel() { close(false); }
+
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    scrim.addEventListener('click', () => close(false), { once: true });
+  });
+}
+
+// ---- イベントリスナー -------------------------------------------------------
+
+refreshBtn.addEventListener('click', fetchRobots);
+startAllBtn.addEventListener('click', startAll);
+stopAllBtn.addEventListener('click', stopAll);
+
+// ---- 初期化 ----------------------------------------------------------------
+
+async function init() {
+  try {
+    const res = await fetch('/api/config');
+    const config = await res.json();
+    NUM_ROBOTS = config.num_robots || 13;
+    if (config.back_url) {
+      const backBtn = document.getElementById('back-btn');
+      backBtn.href = config.back_url;
+      backBtn.style.display = '';
+    }
+  } catch { /* フォールバック: デフォルト値のまま */ }
+  robots = offlineRobots();
+  renderTable();
+  fetchRobots();
+  setInterval(fetchRobots, 4000);
+}
+
+init();

--- a/robot-manager/web/index.html
+++ b/robot-manager/web/index.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ロボットマネージャー</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-25..200&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="m3e-theme.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    .main-scroll {
+      flex: 1;
+      overflow-y: auto;
+      padding: var(--md-sys-spacing-md);
+    }
+
+    /* サマリーバー */
+    .summary-bar {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: var(--md-sys-spacing-md);
+      background-color: var(--md-sys-color-surface-container);
+      border-radius: var(--md-sys-shape-md);
+      padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md);
+      margin-bottom: var(--md-sys-spacing-md);
+    }
+
+    .summary-stat {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.8125rem;
+    }
+
+    .summary-actions {
+      margin-left: auto;
+      display: flex;
+      gap: var(--md-sys-spacing-sm);
+    }
+
+    .last-updated {
+      font-size: 0.75rem;
+      color: var(--md-sys-color-on-surface-variant);
+      margin-left: var(--md-sys-spacing-sm);
+    }
+
+    /* テーブル */
+    .table-wrap {
+      overflow-x: auto;
+    }
+
+    .robot-row.offline {
+      opacity: 0.55;
+    }
+
+    .hw-detail {
+      font-size: 0.8125rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .hw-divider {
+      color: var(--md-sys-color-on-surface-variant);
+      font-size: 0.75rem;
+    }
+
+    /* トースト通知 */
+    #toast-container {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      z-index: 9999;
+    }
+
+    .m3-toast {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      border-radius: var(--md-sys-shape-md);
+      background-color: var(--md-sys-color-surface-container-highest);
+      color: var(--md-sys-color-on-surface);
+      box-shadow: var(--md-sys-elevation-3);
+      font-size: 0.875rem;
+      max-width: 320px;
+      animation: toast-in var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-decelerate);
+    }
+
+    .m3-toast.exit {
+      animation: toast-out var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-accelerate) forwards;
+    }
+
+    .m3-toast--success .material-symbols-outlined { color: var(--md-sys-color-success); }
+    .m3-toast--error .material-symbols-outlined { color: var(--md-sys-color-error); }
+    .m3-toast--info .material-symbols-outlined { color: var(--md-sys-color-info); }
+
+    @keyframes toast-in {
+      from { opacity: 0; transform: translateX(24px); }
+      to   { opacity: 1; transform: translateX(0); }
+    }
+
+    @keyframes toast-out {
+      from { opacity: 1; transform: translateX(0); }
+      to   { opacity: 0; transform: translateX(24px); }
+    }
+
+    /* 確認ダイアログ */
+    .m3-dialog__actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: var(--md-sys-spacing-sm);
+      padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md) var(--md-sys-spacing-md);
+    }
+
+    @media (max-width: 720px) {
+      .col-ip { display: none; }
+      .summary-actions { width: 100%; margin-left: 0; }
+    }
+  </style>
+</head>
+<body>
+  <!-- トップアプリバー -->
+  <nav class="m3-top-app-bar">
+    <a href="#" class="m3-icon-btn m3-icon-btn--sm" id="back-btn" style="display:none">
+      <span class="material-symbols-outlined">arrow_back</span>
+    </a>
+    <div class="m3-top-app-bar__title">
+      <span class="material-symbols-outlined">memory</span>
+      ロボットマネージャー
+    </div>
+    <div class="m3-top-app-bar__actions">
+      <span class="m3-connection-dot" id="conn-dot"></span>
+      <span class="m3-body-small m3-text-on-surface-variant" id="conn-text">接続中...</span>
+    </div>
+  </nav>
+
+  <div class="main-scroll">
+    <!-- サマリーバー -->
+    <div class="summary-bar">
+      <span class="summary-stat">
+        <span class="material-symbols-outlined icon-sm m3-text-success">play_circle</span>
+        稼働中: <strong id="running-count">0</strong>
+      </span>
+      <span class="summary-stat">
+        <span class="material-symbols-outlined icon-sm m3-text-warning">pause_circle</span>
+        停止中: <strong id="stopped-count">0</strong>
+      </span>
+      <span class="summary-stat">
+        <span class="material-symbols-outlined icon-sm m3-text-on-surface-variant">cloud_off</span>
+        オフライン: <strong id="offline-count">0</strong>
+      </span>
+      <span class="last-updated" id="last-updated"></span>
+      <div class="summary-actions">
+        <button class="m3-btn m3-btn--sm m3-btn--success" id="start-all-btn">
+          <span class="material-symbols-outlined icon-sm">play_arrow</span> 全台起動
+        </button>
+        <button class="m3-btn m3-btn--sm m3-btn--error" id="stop-all-btn">
+          <span class="material-symbols-outlined icon-sm">stop</span> 全台停止
+        </button>
+        <button class="m3-btn m3-btn--sm m3-btn--outlined" id="refresh-btn">
+          <span class="material-symbols-outlined icon-sm">sync</span> 更新
+        </button>
+      </div>
+    </div>
+
+    <!-- ロボット一覧テーブル -->
+    <div class="table-wrap">
+      <table class="m3-data-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>状態 / 制御</th>
+            <th class="col-ip">IPアドレス</th>
+            <th>詳細</th>
+          </tr>
+        </thead>
+        <tbody id="table-body"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- 確認ダイアログ -->
+  <div class="m3-dialog-scrim" id="confirm-scrim" style="display:none"></div>
+  <div class="m3-dialog" id="confirm-dialog" style="display:none">
+    <div class="m3-dialog__header">
+      <span class="m3-title-medium" id="confirm-title"></span>
+    </div>
+    <div class="m3-dialog__body m3-body-medium" id="confirm-body"></div>
+    <div class="m3-dialog__actions">
+      <button class="m3-btn m3-btn--text" id="confirm-cancel">キャンセル</button>
+      <button class="m3-btn m3-btn--filled m3-btn--error" id="confirm-ok">停止する</button>
+    </div>
+  </div>
+
+  <!-- トーストコンテナ -->
+  <div id="toast-container"></div>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/robot-manager/web/m3e-theme.css
+++ b/robot-manager/web/m3e-theme.css
@@ -1,0 +1,907 @@
+/*
+ * Material 3 Expressive Design System for Crane Web Debugger
+ * ============================================================
+ * Dark theme optimized for debug tool usage.
+ * Based on M3 Expressive guidelines: expressive color, shape, motion, typography.
+ */
+
+/* ===== DESIGN TOKENS ===== */
+:root {
+  /* --- Color: Primary (Blue) --- */
+  --md-sys-color-primary: #A0C4FF;
+  --md-sys-color-on-primary: #003060;
+  --md-sys-color-primary-container: #1A3A5C;
+  --md-sys-color-on-primary-container: #C8E0FF;
+
+  /* --- Color: Secondary --- */
+  --md-sys-color-secondary: #B8C8E0;
+  --md-sys-color-on-secondary: #1E2A3A;
+  --md-sys-color-secondary-container: #2A3A50;
+  --md-sys-color-on-secondary-container: #D8E4F0;
+
+  /* --- Color: Tertiary (Purple accent) --- */
+  --md-sys-color-tertiary: #D0BCFF;
+  --md-sys-color-on-tertiary: #381E72;
+  --md-sys-color-tertiary-container: #4F378B;
+  --md-sys-color-on-tertiary-container: #EADDFF;
+
+  /* --- Color: Error --- */
+  --md-sys-color-error: #FFB4AB;
+  --md-sys-color-on-error: #690005;
+  --md-sys-color-error-container: #93000A;
+  --md-sys-color-on-error-container: #FFDAD6;
+
+  /* --- Color: Surface --- */
+  --md-sys-color-surface: #121826;
+  --md-sys-color-surface-dim: #0D1117;
+  --md-sys-color-surface-bright: #1E2A40;
+  --md-sys-color-surface-container-lowest: #0A0E18;
+  --md-sys-color-surface-container-low: #141C2E;
+  --md-sys-color-surface-container: #1A2440;
+  --md-sys-color-surface-container-high: #213052;
+  --md-sys-color-surface-container-highest: #2A3C64;
+  --md-sys-color-on-surface: #E2E4E8;
+  --md-sys-color-on-surface-variant: #8C929A;
+  --md-sys-color-outline: #4A5568;
+  --md-sys-color-outline-variant: #2D3748;
+  --md-sys-color-inverse-surface: #E2E4E8;
+  --md-sys-color-inverse-on-surface: #121826;
+  --md-sys-color-scrim: rgba(0, 0, 0, 0.6);
+
+  /* --- Color: Semantic (status) --- */
+  --md-sys-color-success: #66BB6A;
+  --md-sys-color-on-success: #003300;
+  --md-sys-color-success-container: #1B3A1B;
+  --md-sys-color-warning: #FFA726;
+  --md-sys-color-on-warning: #3E2800;
+  --md-sys-color-warning-container: #4A3000;
+  --md-sys-color-info: #42A5F5;
+
+  /* --- Typography --- */
+  --md-sys-typescale-font-family: 'Roboto', 'Noto Sans JP', system-ui, sans-serif;
+  --md-sys-typescale-mono-font-family: 'Roboto Mono', 'Courier New', monospace;
+
+  /* --- Shape (M3E: more rounded, organic) --- */
+  --md-sys-shape-none: 0;
+  --md-sys-shape-xs: 4px;
+  --md-sys-shape-sm: 8px;
+  --md-sys-shape-md: 12px;
+  --md-sys-shape-lg: 16px;
+  --md-sys-shape-xl: 28px;
+  --md-sys-shape-full: 9999px;
+
+  /* --- Elevation (dark theme shadows) --- */
+  --md-sys-elevation-0: none;
+  --md-sys-elevation-1: 0 1px 3px 1px rgba(0,0,0,0.15), 0 1px 2px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-2: 0 2px 6px 2px rgba(0,0,0,0.15), 0 1px 2px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-3: 0 4px 8px 3px rgba(0,0,0,0.15), 0 1px 3px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-4: 0 6px 10px 4px rgba(0,0,0,0.15), 0 2px 3px 0 rgba(0,0,0,0.3);
+  --md-sys-elevation-5: 0 8px 12px 6px rgba(0,0,0,0.15), 0 4px 4px 0 rgba(0,0,0,0.3);
+
+  /* --- Spacing --- */
+  --md-sys-spacing-xs: 4px;
+  --md-sys-spacing-sm: 8px;
+  --md-sys-spacing-md: 16px;
+  --md-sys-spacing-lg: 24px;
+  --md-sys-spacing-xl: 32px;
+  --md-sys-spacing-2xl: 48px;
+
+  /* --- Motion (M3E: physics-based) --- */
+  --md-sys-motion-duration-short: 150ms;
+  --md-sys-motion-duration-medium: 300ms;
+  --md-sys-motion-duration-long: 500ms;
+  --md-sys-motion-easing-standard: cubic-bezier(0.2, 0.0, 0, 1.0);
+  --md-sys-motion-easing-emphasized: cubic-bezier(0.2, 0.0, 0, 1.0);
+  --md-sys-motion-easing-decelerate: cubic-bezier(0.0, 0.0, 0, 1.0);
+  --md-sys-motion-easing-accelerate: cubic-bezier(0.3, 0.0, 0.8, 0.15);
+  --md-sys-motion-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+
+/* ===== BASE RESET & DEFAULTS ===== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  font-family: var(--md-sys-typescale-font-family);
+  background-color: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--md-sys-color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--md-sys-color-on-primary-container);
+}
+
+
+/* ===== TYPOGRAPHY SCALE ===== */
+.m3-display-large   { font-size: 2.25rem;  font-weight: 500; line-height: 2.75rem; letter-spacing: -0.01em; }
+.m3-headline-large  { font-size: 1.75rem;  font-weight: 500; line-height: 2.25rem; }
+.m3-headline-medium { font-size: 1.5rem;   font-weight: 500; line-height: 2rem; }
+.m3-headline-small  { font-size: 1.25rem;  font-weight: 500; line-height: 1.75rem; }
+.m3-title-large     { font-size: 1.25rem;  font-weight: 500; line-height: 1.75rem; }
+.m3-title-medium    { font-size: 1rem;     font-weight: 500; line-height: 1.5rem;  letter-spacing: 0.01em; }
+.m3-title-small     { font-size: 0.875rem; font-weight: 500; line-height: 1.25rem; letter-spacing: 0.01em; }
+.m3-body-large      { font-size: 1rem;     font-weight: 400; line-height: 1.5rem; }
+.m3-body-medium     { font-size: 0.875rem; font-weight: 400; line-height: 1.25rem; letter-spacing: 0.015em; }
+.m3-body-small      { font-size: 0.75rem;  font-weight: 400; line-height: 1rem;    letter-spacing: 0.02em; }
+.m3-label-large     { font-size: 0.875rem; font-weight: 500; line-height: 1.25rem; letter-spacing: 0.01em; }
+.m3-label-medium    { font-size: 0.75rem;  font-weight: 500; line-height: 1rem;    letter-spacing: 0.03em; }
+.m3-label-small     { font-size: 0.6875rem;font-weight: 500; line-height: 1rem;    letter-spacing: 0.03em; }
+
+
+/* ===== MATERIAL SYMBOLS HELPER ===== */
+.material-symbols-outlined {
+  vertical-align: middle;
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+.icon-sm { font-size: 18px; }
+.icon-lg { font-size: 32px; }
+.icon-xl { font-size: 48px; }
+
+.icon-filled {
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+
+/* ===== TOP APP BAR ===== */
+.m3-top-app-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 var(--md-sys-spacing-md);
+  height: 48px;
+  background-color: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  gap: var(--md-sys-spacing-sm);
+}
+
+.m3-top-app-bar__title {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-sm);
+}
+
+.m3-top-app-bar__title .material-symbols-outlined {
+  color: var(--md-sys-color-primary);
+}
+
+.m3-top-app-bar__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-md);
+}
+
+.m3-top-app-bar__nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-xs);
+  list-style: none;
+}
+
+.m3-top-app-bar__nav-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: var(--md-sys-shape-full);
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-top-app-bar__nav-links a:hover {
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+}
+
+
+/* ===== BUTTONS ===== */
+.m3-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--md-sys-spacing-sm);
+  padding: 10px 24px;
+  border: none;
+  border-radius: var(--md-sys-shape-full);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              box-shadow var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              transform var(--md-sys-motion-duration-short) var(--md-sys-motion-spring);
+  text-decoration: none;
+  white-space: nowrap;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.m3-btn:active {
+  transform: scale(0.97);
+}
+
+/* Filled */
+.m3-btn--filled {
+  background-color: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+}
+
+.m3-btn--filled:hover {
+  box-shadow: var(--md-sys-elevation-1);
+  background-color: color-mix(in srgb, var(--md-sys-color-primary) 92%, var(--md-sys-color-on-primary));
+}
+
+/* Filled Tonal */
+.m3-btn--tonal {
+  background-color: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.m3-btn--tonal:hover {
+  box-shadow: var(--md-sys-elevation-1);
+  background-color: color-mix(in srgb, var(--md-sys-color-secondary-container) 88%, var(--md-sys-color-on-secondary-container));
+}
+
+/* Outlined */
+.m3-btn--outlined {
+  background-color: transparent;
+  color: var(--md-sys-color-primary);
+  border: 1px solid var(--md-sys-color-outline);
+}
+
+.m3-btn--outlined:hover {
+  background-color: color-mix(in srgb, var(--md-sys-color-primary) 8%, transparent);
+}
+
+/* Text */
+.m3-btn--text {
+  background-color: transparent;
+  color: var(--md-sys-color-primary);
+  padding: 10px 12px;
+}
+
+.m3-btn--text:hover {
+  background-color: color-mix(in srgb, var(--md-sys-color-primary) 8%, transparent);
+}
+
+/* Icon button */
+.m3-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: var(--md-sys-shape-full);
+  background: transparent;
+  color: var(--md-sys-color-on-surface-variant);
+  cursor: pointer;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-icon-btn:hover {
+  background-color: var(--md-sys-color-surface-container-high);
+}
+
+/* Size variants */
+.m3-btn--sm {
+  padding: 6px 16px;
+  font-size: 0.75rem;
+  height: 32px;
+}
+
+.m3-icon-btn--sm {
+  width: 32px;
+  height: 32px;
+}
+
+.m3-icon-btn--sm .material-symbols-outlined {
+  font-size: 18px;
+}
+
+/* Color variants */
+.m3-btn--success {
+  background-color: var(--md-sys-color-success);
+  color: var(--md-sys-color-on-success);
+}
+
+.m3-btn--error {
+  background-color: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
+}
+
+.m3-btn--warning {
+  background-color: var(--md-sys-color-warning);
+  color: var(--md-sys-color-on-warning);
+}
+
+
+/* ===== CARDS ===== */
+.m3-card {
+  border-radius: var(--md-sys-shape-lg);
+  padding: var(--md-sys-spacing-md);
+  transition: box-shadow var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+              transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-spring),
+              border-radius var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+.m3-card--filled {
+  background-color: var(--md-sys-color-surface-container-highest);
+  color: var(--md-sys-color-on-surface);
+}
+
+.m3-card--elevated {
+  background-color: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  box-shadow: var(--md-sys-elevation-1);
+}
+
+.m3-card--elevated:hover {
+  box-shadow: var(--md-sys-elevation-3);
+}
+
+.m3-card--outlined {
+  background-color: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+/* Interactive card (clickable) */
+.m3-card--interactive {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.m3-card--interactive:hover {
+  transform: translateY(-4px);
+  border-radius: var(--md-sys-shape-xl);
+  color: inherit;
+}
+
+.m3-card--interactive:active {
+  transform: translateY(-2px) scale(0.99);
+}
+
+
+/* ===== BADGE ===== */
+.m3-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  border-radius: var(--md-sys-shape-full);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  min-width: 20px;
+  min-height: 20px;
+}
+
+.m3-badge--primary {
+  background-color: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+}
+
+.m3-badge--secondary {
+  background-color: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.m3-badge--success {
+  background-color: var(--md-sys-color-success);
+  color: var(--md-sys-color-on-success);
+}
+
+.m3-badge--error {
+  background-color: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
+}
+
+.m3-badge--warning {
+  background-color: var(--md-sys-color-warning);
+  color: var(--md-sys-color-on-warning);
+}
+
+
+/* ===== DATA TABLE ===== */
+.m3-data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.m3-data-table th {
+  color: var(--md-sys-color-on-surface-variant);
+  font-weight: 500;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--md-sys-color-outline);
+  background-color: var(--md-sys-color-surface-container);
+}
+
+.m3-data-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  color: var(--md-sys-color-on-surface);
+  vertical-align: middle;
+}
+
+.m3-data-table tbody tr {
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-data-table tbody tr:hover {
+  background-color: var(--md-sys-color-surface-container-low);
+}
+
+.m3-data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Compact table */
+.m3-data-table--compact th,
+.m3-data-table--compact td {
+  padding: 4px 8px;
+  font-size: 0.75rem;
+}
+
+/* Borderless table for detail panels */
+.m3-data-table--borderless td {
+  border-bottom: none;
+  padding: 3px 8px;
+}
+
+.m3-data-table--borderless td:first-child {
+  color: var(--md-sys-color-on-surface-variant);
+  white-space: nowrap;
+  padding-right: 12px;
+  font-size: 0.8125rem;
+}
+
+
+/* ===== DIALOG (Modal replacement) ===== */
+.m3-dialog-scrim {
+  position: fixed;
+  inset: 0;
+  background-color: var(--md-sys-color-scrim);
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+              visibility var(--md-sys-motion-duration-medium);
+}
+
+.m3-dialog-scrim.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.m3-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.9);
+  z-index: 1001;
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  border-radius: var(--md-sys-shape-xl);
+  padding: var(--md-sys-spacing-lg);
+  max-width: 420px;
+  width: 90%;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: var(--md-sys-elevation-5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized),
+              transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized),
+              visibility var(--md-sys-motion-duration-medium);
+}
+
+.m3-dialog.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.m3-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--md-sys-spacing-md);
+}
+
+.m3-dialog__title {
+  font-size: 1.125rem;
+  font-weight: 500;
+  color: var(--md-sys-color-on-surface);
+}
+
+.m3-dialog__body {
+  font-size: 0.8125rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.m3-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--md-sys-spacing-sm);
+  margin-top: var(--md-sys-spacing-lg);
+}
+
+
+/* ===== EXPANSION PANEL (details/summary) ===== */
+details.m3-expansion {
+  background-color: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-md);
+  overflow: hidden;
+}
+
+details.m3-expansion summary {
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-sm);
+  padding: 10px var(--md-sys-spacing-md);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--md-sys-color-on-surface);
+  user-select: none;
+  list-style: none;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+details.m3-expansion summary::-webkit-details-marker { display: none; }
+
+details.m3-expansion summary::after {
+  content: 'expand_more';
+  font-family: 'Material Symbols Outlined';
+  font-size: 20px;
+  margin-left: auto;
+  color: var(--md-sys-color-on-surface-variant);
+  transition: transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+details.m3-expansion[open] summary::after {
+  transform: rotate(180deg);
+}
+
+details.m3-expansion summary:hover {
+  background-color: var(--md-sys-color-surface-container-high);
+}
+
+details.m3-expansion .m3-expansion__body {
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-md) var(--md-sys-spacing-md);
+}
+
+
+/* ===== LINEAR PROGRESS ===== */
+.m3-linear-progress {
+  height: 4px;
+  background-color: var(--md-sys-color-surface-container-highest);
+  border-radius: var(--md-sys-shape-full);
+  overflow: hidden;
+}
+
+.m3-linear-progress__bar {
+  height: 100%;
+  border-radius: var(--md-sys-shape-full);
+  background-color: var(--md-sys-color-primary);
+  transition: width var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+
+/* ===== SELECT ===== */
+.m3-select {
+  appearance: none;
+  padding: 8px 32px 8px 12px;
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: var(--md-sys-shape-sm);
+  background-color: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%238C929A'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 4px center;
+  background-size: 20px;
+  transition: border-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-select:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+}
+
+
+/* ===== CHECKBOX ===== */
+.m3-checkbox {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--md-sys-color-outline);
+  border-radius: 3px;
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: background-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard),
+              border-color var(--md-sys-motion-duration-short) var(--md-sys-motion-easing-standard);
+}
+
+.m3-checkbox:checked {
+  background-color: var(--md-sys-color-primary);
+  border-color: var(--md-sys-color-primary);
+}
+
+.m3-checkbox:checked::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 6px;
+  height: 10px;
+  border: solid var(--md-sys-color-on-primary);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+
+/* ===== CONNECTION INDICATOR ===== */
+.m3-connection-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--md-sys-shape-full);
+  background-color: var(--md-sys-color-error);
+  display: inline-block;
+  flex-shrink: 0;
+  transition: background-color var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+              box-shadow var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+.m3-connection-dot.connected {
+  background-color: var(--md-sys-color-success);
+  box-shadow: 0 0 8px var(--md-sys-color-success);
+}
+
+
+/* ===== SIDE SHEET ===== */
+.m3-side-sheet {
+  position: fixed;
+  top: 0;
+  right: -400px;
+  width: 380px;
+  height: 100%;
+  background-color: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  z-index: 1050;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--md-sys-elevation-4);
+  transition: right var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-emphasized);
+}
+
+.m3-side-sheet.open {
+  right: 0;
+}
+
+.m3-side-sheet__header {
+  padding: var(--md-sys-spacing-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  flex-shrink: 0;
+}
+
+.m3-side-sheet__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--md-sys-spacing-md);
+}
+
+.m3-side-sheet__section-title {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--md-sys-color-on-surface-variant);
+  margin: var(--md-sys-spacing-md) 0 var(--md-sys-spacing-xs);
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-xs);
+}
+
+.m3-side-sheet__backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1040;
+  background-color: var(--md-sys-color-scrim);
+}
+
+
+/* ===== CHIP ===== */
+.m3-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: var(--md-sys-shape-sm);
+  font-size: 0.75rem;
+  font-weight: 500;
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+
+/* ===== SECTION TITLE ===== */
+.m3-section-title {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--md-sys-color-on-surface-variant);
+  padding: var(--md-sys-spacing-sm) var(--md-sys-spacing-xs) var(--md-sys-spacing-xs);
+  margin-bottom: var(--md-sys-spacing-xs);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+
+/* ===== SCROLLBAR (for dark theme) ===== */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--md-sys-color-surface-container-highest);
+  border-radius: var(--md-sys-shape-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--md-sys-color-outline);
+}
+
+
+/* ===== LAYOUT UTILITIES ===== */
+.m3-flex           { display: flex; }
+.m3-flex-col       { display: flex; flex-direction: column; }
+.m3-flex-row       { display: flex; flex-direction: row; }
+.m3-flex-wrap      { flex-wrap: wrap; }
+.m3-flex-1         { flex: 1; }
+.m3-flex-shrink-0  { flex-shrink: 0; }
+.m3-inline-flex    { display: inline-flex; }
+.m3-items-center   { align-items: center; }
+.m3-items-start    { align-items: flex-start; }
+.m3-items-end      { align-items: flex-end; }
+.m3-justify-center { justify-content: center; }
+.m3-justify-between{ justify-content: space-between; }
+.m3-justify-end    { justify-content: flex-end; }
+.m3-self-center    { align-self: center; }
+
+/* Grid */
+.m3-grid           { display: grid; }
+.m3-grid-cols-2    { grid-template-columns: repeat(2, 1fr); }
+.m3-grid-cols-3    { grid-template-columns: repeat(3, 1fr); }
+.m3-grid-cols-4    { grid-template-columns: repeat(4, 1fr); }
+
+@media (min-width: 768px) {
+  .m3-md-grid-cols-2 { grid-template-columns: repeat(2, 1fr); }
+  .m3-md-grid-cols-3 { grid-template-columns: repeat(3, 1fr); }
+  .m3-md-grid-cols-4 { grid-template-columns: repeat(4, 1fr); }
+}
+
+.m3-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--md-sys-spacing-md);
+}
+
+
+/* ===== SPACING UTILITIES ===== */
+.m3-gap-xs  { gap: var(--md-sys-spacing-xs); }
+.m3-gap-sm  { gap: var(--md-sys-spacing-sm); }
+.m3-gap-md  { gap: var(--md-sys-spacing-md); }
+.m3-gap-lg  { gap: var(--md-sys-spacing-lg); }
+.m3-gap-xl  { gap: var(--md-sys-spacing-xl); }
+
+.m3-p-0     { padding: 0; }
+.m3-p-xs    { padding: var(--md-sys-spacing-xs); }
+.m3-p-sm    { padding: var(--md-sys-spacing-sm); }
+.m3-p-md    { padding: var(--md-sys-spacing-md); }
+.m3-p-lg    { padding: var(--md-sys-spacing-lg); }
+.m3-px-md   { padding-left: var(--md-sys-spacing-md); padding-right: var(--md-sys-spacing-md); }
+.m3-px-lg   { padding-left: var(--md-sys-spacing-lg); padding-right: var(--md-sys-spacing-lg); }
+.m3-py-xs   { padding-top: var(--md-sys-spacing-xs); padding-bottom: var(--md-sys-spacing-xs); }
+.m3-py-sm   { padding-top: var(--md-sys-spacing-sm); padding-bottom: var(--md-sys-spacing-sm); }
+.m3-py-md   { padding-top: var(--md-sys-spacing-md); padding-bottom: var(--md-sys-spacing-md); }
+
+.m3-m-0     { margin: 0; }
+.m3-mb-0    { margin-bottom: 0; }
+.m3-mb-xs   { margin-bottom: var(--md-sys-spacing-xs); }
+.m3-mb-sm   { margin-bottom: var(--md-sys-spacing-sm); }
+.m3-mb-md   { margin-bottom: var(--md-sys-spacing-md); }
+.m3-mb-lg   { margin-bottom: var(--md-sys-spacing-lg); }
+.m3-mt-sm   { margin-top: var(--md-sys-spacing-sm); }
+.m3-mt-md   { margin-top: var(--md-sys-spacing-md); }
+.m3-ms-auto { margin-left: auto; }
+.m3-me-sm   { margin-right: var(--md-sys-spacing-sm); }
+.m3-me-md   { margin-right: var(--md-sys-spacing-md); }
+
+
+/* ===== TEXT UTILITIES ===== */
+.m3-text-primary            { color: var(--md-sys-color-primary); }
+.m3-text-secondary          { color: var(--md-sys-color-secondary); }
+.m3-text-tertiary           { color: var(--md-sys-color-tertiary); }
+.m3-text-on-surface         { color: var(--md-sys-color-on-surface); }
+.m3-text-on-surface-variant { color: var(--md-sys-color-on-surface-variant); }
+.m3-text-error              { color: var(--md-sys-color-error); }
+.m3-text-success            { color: var(--md-sys-color-success); }
+.m3-text-warning            { color: var(--md-sys-color-warning); }
+.m3-text-info               { color: var(--md-sys-color-info); }
+
+.m3-text-center  { text-align: center; }
+.m3-text-end     { text-align: right; }
+.m3-fw-medium    { font-weight: 500; }
+.m3-fw-bold      { font-weight: 700; }
+.m3-text-mono    { font-family: var(--md-sys-typescale-mono-font-family); }
+.m3-tabular-nums { font-variant-numeric: tabular-nums; }
+
+.m3-truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+
+/* ===== DISPLAY UTILITIES ===== */
+.m3-hidden     { display: none !important; }
+.m3-block      { display: block; }
+.m3-w-full     { width: 100%; }
+.m3-h-full     { height: 100%; }
+.m3-overflow-hidden  { overflow: hidden; }
+.m3-overflow-y-auto  { overflow-y: auto; }
+.m3-relative   { position: relative; }
+.m3-absolute   { position: absolute; }
+.m3-fixed      { position: fixed; }
+.m3-inset-0    { inset: 0; }


### PR DESCRIPTION
## Summary

- craneリポジトリの `docker/dev/robot-manager/` をこのリポジトリへ移行
- Orion_CM4単体でWindows/Linux両対応のdocker-composeを追加
- GitHub Actionsでイメージをビルドし `ghcr.io/ibis-ssl/robot-manager:latest` に公開

## 変更点

### 新規追加ファイル

| ファイル | 内容 |
|---------|------|
| `robot-manager/Dockerfile` | Python 3.12-slimベース |
| `robot-manager/server.py` | `/api/config` エンドポイント追加（`BACK_URL`, `NUM_ROBOTS`を提供） |
| `robot-manager/web/index.html` | トップバーに戻るボタン追加（`BACK_URL`未指定時は非表示） |
| `robot-manager/web/app.js` | `NUM_ROBOTS`を`/api/config`から動的取得、戻るボタン制御 |
| `robot-manager/web/m3e-theme.css` | Material 3 Expressiveダークテーマ |
| `docker-compose.yaml` | Windows対応（ポートマッピング方式、`network_mode: host`不使用） |
| `.github/workflows/robot-manager-docker.yml` | `robot-manager/**`変更時にDockerイメージをビルド・push |

### 環境変数

| 変数 | デフォルト | 説明 |
|-----|----------|------|
| `HTTP_PORT` | 8090 | リッスンポート |
| `NUM_ROBOTS` | 13 | ロボット台数 |
| `ROBOT_IP_BASE` | 192.168.20. | ロボットIPベース |
| `ROBOT_IP_OFFSET` | 100 | IPオフセット |
| `ROBOT_PORT` | 8000 | ロボット側HTTPポート |
| `HTTP_TIMEOUT_SEC` | 0.8 | タイムアウト（秒） |
| `BACK_URL` | （空） | 戻るボタンのリンク先（空の場合は非表示） |

## Test plan

- [ ] `docker compose up` でhttp://localhost:8090 が起動することを確認
- [ ] `BACK_URL=http://example.com docker compose up` で戻るボタンが表示されることを確認
- [ ] `BACK_URL`未指定時に戻るボタンが非表示になることを確認
- [ ] mainブランチへのマージ後、GitHub ActionsでDockerイメージがghcr.ioに公開されることを確認
- [ ] ghcr.ioのパッケージvisibilityをpublicに設定する（必要に応じて）

## 関連

- crane側PR: ibis-ssl/crane#1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)