### PR TITLE
fix(robot-manager): BrokenPipeError / ConnectionResetErrorをサイレント抑制

### DIFF
--- a/robot-manager/server.py
+++ b/robot-manager/server.py
@@ -224,8 +224,17 @@ class Handler(BaseHTTPRequestHandler):
         return
 
 
+class Server(ThreadingHTTPServer):
+    def handle_error(self, request, client_address) -> None:
+        import sys
+
+        if sys.exc_info()[0] in (BrokenPipeError, ConnectionResetError):
+            return
+        super().handle_error(request, client_address)
+
+
 def main() -> None:
-    server = ThreadingHTTPServer(("0.0.0.0", HTTP_PORT), Handler)
+    server = Server(("0.0.0.0", HTTP_PORT), Handler)
     print(f"robot-manager listening on http://0.0.0.0:{HTTP_PORT}")
 
     def handle_signal(signum, frame):


### PR DESCRIPTION
## Summary

ブラウザがポーリング中に接続を切った際に発生する `BrokenPipeError` / `ConnectionResetError` のスタックトレースがログに出力される問題を修正。

## 原因

`/api/robots` の応答に約0.8秒（タイムアウト × ロボット台数）かかる場合があり、
次のポーリングサイクルが先に始まったブラウザが前のリクエストを切断することがある。
これは無害だが、デフォルトの `handle_error` がスタックトレースを標準エラーに出力する。

## 変更内容

`ThreadingHTTPServer` のサブクラス `Server` を作成し、
`handle_error` をオーバーライドして `BrokenPipeError` / `ConnectionResetError` を抑制する。

```
crane-robot-manager | Exception occurred during processing of request from ('127.0.0.1', 45044)
crane-robot-manager | BrokenPipeError: [Errno 32] Broken pipe
```

このログが出なくなる。

## Test plan

- [ ] `docker compose up` 後にブラウザで開き、通常操作でエラーログが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)